### PR TITLE
Customize Polygon Corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.0
+
+* Add `CornerShape` enum with `sharp`, `bevel`, `round`, `fillet` and `inset` variants.
+* Add `Corner` model class with a `shape` and a `radius`.
+* Add named constructors for each `CornerShape` variant.
+* Add `Corner` field `corners` to `RegularPolygon`.
+* Calculate `Path` in `RegularPolygon.getPath()` based on `corners` field.
+
 ## 0.1.0
 
 * Add `RegularPolygon` model class with `sides`, `rotation`, `innerAngle` and `getPath()`.

--- a/lib/src/model/corner.dart
+++ b/lib/src/model/corner.dart
@@ -43,6 +43,39 @@ class Corner {
   })  : shape = shape ?? CornerShape.sharp,
         radius = (radius ?? 0).toDouble().clamp(0, 1);
 
+  /// Create a new sharp corner.
+  Corner.sharp()
+      : this(
+          shape: CornerShapae.sharp,
+        );
+
+  /// Create a new beveled corner.
+  Corner.bevel(num radius)
+      : this(
+          shape: CornerShape.bevel,
+          radius: radius,
+        );
+
+  /// Create a new rounded corner.
+  Corner.round(num radius)
+      : this(
+          shape: CornerShape.round,
+          radius: radius,
+        );
+
+  /// Create a new filleted corner.
+  Corner.fillet(num radius)
+      : this(
+          shape: CornerShape.fillet,
+          radius: radius,
+        );
+
+  /// Create a new inset corner.
+  Corner.inset()
+      : this(
+          shape: CornerShape.inset,
+        );
+
   /// The shape of the corner.
   ///
   /// See [CornerShape] for more.

--- a/lib/src/model/corner.dart
+++ b/lib/src/model/corner.dart
@@ -26,3 +26,36 @@ enum CornerShape {
   // TODO: Add comment.
   inset,
 }
+
+/// A class representing corners of a two dimensional shape.
+///
+/// A [Corner] has a specific [CornerShape] and an optional
+/// [radius], which is only required for some corner shapes.
+class Corner {
+  /// Create a new [Corner] object.
+  ///
+  /// The [shape] defaults to [CornerShape.hard].
+  ///
+  /// The [radius] defaults to zero.
+  Corner({
+    CornerShape? shape,
+    num? radius,
+  })  : shape = shape ?? CornerShape.sharp,
+        radius = (radius ?? 0).toDouble().clamp(0, 1);
+
+  /// The shape of the corner.
+  ///
+  /// See [CornerShape] for more.
+  final CornerShape shape;
+
+  /// The radius of the corner.
+  ///
+  /// This is a decimal percentage factor setting
+  /// the corner radius to anywhere between the
+  /// minimum and maximum possible radius and is
+  /// thus clamped to be between 0 and 1.
+  ///
+  /// This has no effect with a [shape] of
+  /// [CornerShape.sharp] or [CornerShape.inset].
+  final double radius;
+}

--- a/lib/src/model/corner.dart
+++ b/lib/src/model/corner.dart
@@ -1,0 +1,28 @@
+/// Different shapes of corners.
+///
+/// These define how the intersection of
+/// two converging lines look like.
+enum CornerShape {
+  /// The two lines making up the corner
+  /// simply meet in a sharp point.
+  sharp,
+
+  /// Another shorter line segment is added
+  /// in between the two lines making up
+  /// the corner.
+  bevel,
+
+  /// The corner is rounded off smoothly
+  /// by following a circle segment that
+  /// is tangential to both lines making
+  /// up the corner.
+  round,
+
+  /// Similar to [CornerShape.round], but
+  /// instead of rounding outward, a circle
+  /// segment is cut out of the corner.
+  fillet,
+
+  // TODO: Add comment.
+  inset,
+}

--- a/lib/src/model/regular_polygon.dart
+++ b/lib/src/model/regular_polygon.dart
@@ -1,6 +1,12 @@
 import 'dart:math';
 import 'dart:ui';
 
+import 'package:clip_regular_polygon/model/corner.dart';
+
+// Export the Corner type to users of the RegularPolygon
+// class, as it is needed for a constructor argument.
+export 'package:clip_regular_polygon/model/corner.dart';
+
 /// A class representing an abstract regular polygon.
 ///
 /// A regular polygon is an equiangular and equilateral
@@ -24,47 +30,59 @@ class RegularPolygon {
   RegularPolygon({
     required this.sides,
     num? rotation,
+    Corner? corners,
   })  : assert(sides >= 3),
-        rotation = (rotation ?? 0 % 360).toDouble();
+        rotation = (rotation ?? 0 % 360).toDouble(),
+        corners = corners ?? Corner();
 
   /// Create a [RegularPolygon] with three sides.
   RegularPolygon.triangle({
     num? rotation,
+    Corner? corners,
   }) : this(
           sides: 3,
           rotation: rotation,
+          corners: corners,
         );
 
   /// Create a [RegularPolygon] with four sides.
   RegularPolygon.square({
     num? rotation,
+    Corner? corners,
   }) : this(
           sides: 4,
           rotation: rotation,
+          corners: corners,
         );
 
   /// Create a [RegularPolygon] with five sides.
   RegularPolygon.pentagon({
     num? rotation,
+    Corner? corners,
   }) : this(
           sides: 5,
           rotation: rotation,
+          corners: corners,
         );
 
   /// Create a [RegularPolygon] with six sides.
   RegularPolygon.hexagon({
     num? rotation,
+    Corner? corners,
   }) : this(
           sides: 6,
           rotation: rotation,
+          corners: corners,
         );
 
   /// Create a [RegularPolygon] with eight sides.
   RegularPolygon.octagon({
     num? rotation,
+    Corner? corners,
   }) : this(
           sides: 8,
           rotation: rotation,
+          corners: corners,
         );
 
   /// The numer of sides of the polygon.
@@ -82,6 +100,11 @@ class RegularPolygon {
   /// The polygon is rotated [rotation] degrees
   /// around its center.
   final double rotation;
+
+  /// The corners of the polygon.
+  ///
+  /// See the [Corner] class for more.
+  final Corner corners;
 
   /// The angle between two sides of the polygon.
   double get innerAngle => 360 / sides;

--- a/lib/src/model/regular_polygon.dart
+++ b/lib/src/model/regular_polygon.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:clip_regular_polygon/model/corner.dart';
+import 'package:clip_regular_polygon/util/extensions.dart';
 
 // Export the Corner type to users of the RegularPolygon
 // class, as it is needed for a constructor argument.
@@ -106,9 +107,6 @@ class RegularPolygon {
   /// See the [Corner] class for more.
   final Corner corners;
 
-  /// The angle between two sides of the polygon.
-  double get innerAngle => 360 / sides;
-
   /// Return the shape of the polygon as a [Path].
   ///
   /// The generated polygon will have [sides] sides
@@ -119,33 +117,149 @@ class RegularPolygon {
   /// meaning the distance from the center to any
   /// corner vertex will be of length 1.
   Path getPath() {
-    // Generate the angles at which the vertices of
-    // the polygon should be positioned.
-    final List<double> angles = List.generate(
-      // The number of sides equals the number of
-      // vertices.
-      sides,
-      // Each angle is [innerAngle] big and offset
-      // from zero degrees by [rotation].
-      (index) => index * innerAngle + rotation,
-    );
-
-    // Calculate the position of the vertices as an
-    // offset of unit length 1 from the origin
-    // outwards in the directions defined by [angles].
-    final List<Offset> vertices = angles
-        .map(
-          // Convert angles from degrees to radians
-          // as expected by [Offset.fromDirection].
-          (angle) => angle * pi / 180,
-        )
-        .map(
-          (angle) => Offset.fromDirection(angle),
-        )
-        .toList();
-
-    // Return the closed polygon created by these
-    // vertices.
-    return Path()..addPolygon(vertices, true);
+    // Return the appropriate path for the corner shape.
+    switch (corners.shape) {
+      case CornerShape.sharp:
+        return _normalPath;
+      case CornerShape.bevel:
+        return _bevelPath;
+      case CornerShape.round:
+        return _roundPath;
+      case CornerShape.fillet:
+        return _filletPath;
+      case CornerShape.inset:
+        return _getInsetPath();
+    }
   }
+
+  /// Each regular polygon can be described as a set of
+  /// equilateral triangles rotationally symmetrically
+  /// arranged around a center.
+  /// The angle of the corner of all of those similar
+  /// triangles on the point where they meet in the
+  /// center of the polygon is this [innerAngle].
+  late final double _innerAngle = (() => (360 / sides).toRadians())();
+
+  late final double _magicAngle = (() => _innerAngle / 2)();
+
+  // Multiply the maximum possible radius by the [Corner.radius] factor.
+  late final double _radius = (() => cos(_magicAngle) * corners.radius)();
+
+  late final List<double> _cornerAngles = (() => List.generate(
+        sides,
+        (index) => index * _innerAngle + rotation.toRadians() - 90.toRadians(),
+      ))();
+
+  late final List<Offset> _cornerPoints = (() => _cornerAngles
+      .map(
+        (angle) => Offset.fromDirection(angle),
+      )
+      .toList())();
+
+  late final List<Offset> _secondaryPoints = (() => _cornerAngles.expand(
+        (angle) {
+          Offset primaryPoint = Offset.fromDirection(
+            angle,
+            1 - (_radius / cos(_magicAngle)),
+          );
+          return [
+            primaryPoint +
+                Offset.fromDirection(
+                  angle - _magicAngle,
+                  _radius,
+                ),
+            primaryPoint +
+                Offset.fromDirection(
+                  angle + _magicAngle,
+                  _radius,
+                ),
+          ];
+        },
+      ).toList())();
+
+  // The path of this polygon with sharp corners.
+  late final Path _normalPath = (() => Path()
+    ..addPolygon(
+      _cornerPoints,
+      true,
+    ))();
+
+  // The path of this polygon with beveled corners.
+  late final Path _bevelPath = (() => Path()
+    ..addPolygon(
+      _secondaryPoints,
+      true,
+    ))();
+
+  // The path of this polygon with rounded corners.
+  late final Path _roundPath = _getArcPath(
+    clockwise: true,
+  );
+
+  // The path of this polygon with filleted corners.
+  late final Path _filletPath = _getArcPath(
+    clockwise: false,
+  );
+
+  // Return the path of this polygon with arced corners.
+  //
+  // Set [clockwise] to determine in which direction the
+  // corners should arc.
+  Path _getArcPath({
+    required bool clockwise,
+  }) {
+    // Create new Path and move to first point.
+    Path path = Path()
+      ..moveTo(
+        _secondaryPoints.first.dx,
+        _secondaryPoints.first.dy,
+      );
+
+    // Draw arcs and lines between the secondary points of the
+    // polygon in an alternating manner.
+    for (int i = 0; i < _secondaryPoints.length - 1; i += 2) {
+      path.arcToPoint(
+        _secondaryPoints[i + 1],
+        radius: Radius.circular(_radius),
+        clockwise: clockwise,
+      );
+
+      path.lineTo(
+        _secondaryPoints[(i + 2) % _secondaryPoints.length].dx,
+        _secondaryPoints[(i + 2) % _secondaryPoints.length].dy,
+      );
+    }
+
+    // Return the closed polygon created by these sub-paths.
+    return path;
+  }
+
+  // The path of this polygon with inset corners.
+  //
+  // TODO: The math is still off.
+  Path _getInsetPath() => Path()
+    ..addPolygon(
+      _cornerAngles.expand(
+        (angle) {
+          Offset primaryPoint = Offset.fromDirection(
+            angle,
+            1 - (_radius / cos(_magicAngle)),
+          );
+          return [
+            primaryPoint +
+                Offset.fromDirection(
+                  angle - _magicAngle,
+                  _radius,
+                ),
+            primaryPoint,
+            primaryPoint +
+                Offset.fromDirection(
+                  angle + _magicAngle,
+                  _radius,
+                ),
+          ];
+        },
+      ).toList(),
+      true,
+    );
 }

--- a/lib/src/util/extensions.dart
+++ b/lib/src/util/extensions.dart
@@ -1,0 +1,11 @@
+import 'dart:math';
+
+/// An extension to convert degrees to radians.
+///
+/// This is an extension on the [num] type, so
+/// it can be used on [int]s and [double]s.
+extension ToRadians on num {
+  /// Return this value interpreted as degrees,
+  /// converted into radians.
+  double toRadians() => this * pi / 180;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: clip_regular_polygon
 description: Exposes functionality to clip any widget into the shape of any regular polygon, with some extra options.
 repository: https://github.com/JimGerth/clip_regular_polygon-flutter
 issue_tracker: https://github.com/JimGerth/clip_regular_polygon-flutter/issues
-version: 0.1.0
+version: 0.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Add a custom corner model supporting different corner shapes and radii.
These can be now set in the `RegularPolygon` model to change its appearance.
However the `getPath()` method does not yet take the corner type into account.

TODO:
- [ ] Add documentation in various places (labeled with `TODO` in code)
- [ ] Implement `getPath()` for different corner types.
  - [x] `sharp`
  - [x] `bevel`
  - [x] `round`
  - [x] `fillet`
  - [ ] `inset`
- [x] Also this is upstream of #4, so that needs to be merged first anyway :)

Fixes #6.