### PR TITLE
Add linter rules to CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,11 +24,8 @@ jobs:
         with:
           channel: stable
 
-      - name: Install dependencies
-        run: flutter pub get
-
       - name: Analyze source code
-        run: flutter analyze --fatal-infos --fatal-warnings
+        run: flutter analyze --pub --fatal-infos --fatal-warnings
 
   format:
     runs-on: ubuntu-latest

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lint/analysis_options_package.yaml

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,9 @@
 include: package:lint/analysis_options_package.yaml
+
+linter:
+  rules:
+    - public_member_api_docs
+    - lines_longer_than_80_chars
+    - always_specify_types
+    - prefer_single_quotes
+    - sort_constructors_first

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,3 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+
+dev_dependencies:
+  lint: ^1.0.0


### PR DESCRIPTION
Add default analysis options from the [lint](https://pub.dev/packages/lint) package.
Also add some more custom linter rules and update the `.github` workflow.